### PR TITLE
Prohibit gcc padding optimization of struct inode_disk

### DIFF
--- a/src/filesys/inode.c
+++ b/src/filesys/inode.c
@@ -12,7 +12,7 @@
 
 /* On-disk inode.
    Must be exactly BLOCK_SECTOR_SIZE bytes long. */
-struct inode_disk
+struct __attribute__((__packed__)) inode_disk
   {
     block_sector_t start;               /* First data sector. */
     off_t length;                       /* File size in bytes. */


### PR DESCRIPTION
Current struct contains just int types, so gcc won't add any paddings, but if someone changes the struct, even if he uses BLOCK_SECTOR_SIZE bytes in total, gcc might add paddings and it will break the code.