### PR TITLE
Prohibit gcc padding optimization of struct inode_disk

### DIFF
--- a/src/filesys/inode.c
+++ b/src/filesys/inode.c
@@ -18,7 +18,7 @@ struct inode_disk
     off_t length;                       /* File size in bytes. */
     unsigned magic;                     /* Magic number. */
     uint32_t unused[125];               /* Not used. */
-  };
+  } PACKED;
 
 /* Returns the number of sectors to allocate for an inode SIZE
    bytes long. */

--- a/src/filesys/inode.c
+++ b/src/filesys/inode.c
@@ -6,6 +6,7 @@
 #include "filesys/filesys.h"
 #include "filesys/free-map.h"
 #include "threads/malloc.h"
+#include "lib/packed.h"
 
 /* Identifies an inode. */
 #define INODE_MAGIC 0x494e4f44


### PR DESCRIPTION
Current struct contains just int types, so gcc won't add any paddings, but if someone changes the struct, even if he uses BLOCK_SECTOR_SIZE bytes in total, gcc might add paddings and it will break the code.