### PR TITLE
redundant code

### DIFF
--- a/src/filesys/inode.c
+++ b/src/filesys/inode.c
@@ -296,13 +296,7 @@ inode_write_at (struct inode *inode, const void *buffer_, off_t size,
                 break;
             }
 
-          /* If the sector contains data before or after the chunk
-             we're writing, then we need to read in the sector
-             first.  Otherwise we start with a sector of all zeros. */
-          if (sector_ofs > 0 || chunk_size < sector_left) 
-            block_read (fs_device, sector_idx, bounce);
-          else
-            memset (bounce, 0, BLOCK_SECTOR_SIZE);
+          block_read (fs_device, sector_idx, bounce);
           memcpy (bounce + sector_ofs, buffer + bytes_written, chunk_size);
           block_write (fs_device, sector_idx, bounce);
         }


### PR DESCRIPTION
 if (sector_ofs > 0 || chunk_size < sector_left)  is never false, lets call it target if.

when target if is checked  (sector_ofs == 0 && chunk_size == BLOCK_SECTOR_SIZE) == false
so there is 3 case
(sector_ofs != 0 && chunk_size == BLOCK_SECTOR_SIZE) == true
sector_ofs can not be less then 0, so target if is true.

(sector_ofs != 0 && chunk_size < BLOCK_SECTOR_SIZE) == true
sector_ofs can not be less then 0, so target if is true.

(sector_ofs == 0 && chunk_size < BLOCK_SECTOR_SIZE) == true
sector_left = BLOCK_SECTOR_SIZE - sector_ofs 
-> sector_left = BLOCK_SECTOR_SIZE
-> target iif is true.